### PR TITLE
Gripper frames

### DIFF
--- a/qibullet/robot_data/pepper_1.7/pepper.urdf
+++ b/qibullet/robot_data/pepper_1.7/pepper.urdf
@@ -499,7 +499,7 @@
   <joint name="LGripper" type="fixed">
     <parent link="l_wrist"/>
     <child link="l_gripper"/>
-    <origin rpy="-2.355 0.0 -1.57" xyz="0.07 0.0 -0.01802319018"/>
+    <origin rpy="-3.14 0.0 -1.57" xyz="0.07 0.0 -0.01802319018"/>
     <axis xyz="0 0 0"/>
   </joint>
   <link name="l_gripper">
@@ -698,7 +698,7 @@
   <joint name="RGripper" type="fixed">
     <parent link="r_wrist"/>
     <child link="r_gripper"/>
-    <origin rpy="2.355 0 1.57" xyz="0.07 0.0 -0.01802319018"/>
+    <origin rpy="3.14 0 1.57" xyz="0.07 0.0 -0.01802319018"/>
     <axis xyz="0 0 0"/>
   </joint>
   <link name="r_gripper">

--- a/qibullet/robot_data/pepper_1.7/pepper.urdf
+++ b/qibullet/robot_data/pepper_1.7/pepper.urdf
@@ -496,14 +496,26 @@
       <origin rpy="0 0 0" xyz="0 0 0"/>
     </collision>
   </link>
-  <joint name="LHand" type="revolute">
+  <joint name="LGripper" type="fixed">
     <parent link="l_wrist"/>
     <child link="l_gripper"/>
+    <origin rpy="-2.355 0.0 -1.57" xyz="0.07 0.0 -0.01802319018"/>
+    <axis xyz="0 0 0"/>
+  </joint>
+  <link name="l_gripper">
+    <inertial>
+      <mass value="2e-03"/>
+      <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
+    </inertial>
+  </link>
+  <joint name="LHand" type="revolute">
+    <parent link="l_wrist"/>
+    <child link="l_hand"/>
     <origin rpy="0 0 0" xyz="0.025 0 0"/>
     <axis xyz="1.0 0 0"/>
     <limit effort="0.144" lower="0.02" upper="0.98" velocity="12.56"/>
   </joint>
-  <link name="l_gripper">
+  <link name="l_hand">
     <inertial>
       <mass value="2e-03"/>
       <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
@@ -683,14 +695,26 @@
       <origin rpy="0 0 0" xyz="0 0 0"/>
     </collision>
   </link>
-  <joint name="RHand" type="revolute">
+  <joint name="RGripper" type="fixed">
     <parent link="r_wrist"/>
     <child link="r_gripper"/>
+    <origin rpy="2.355 0 1.57" xyz="0.07 0.0 -0.01802319018"/>
+    <axis xyz="0 0 0"/>
+  </joint>
+  <link name="r_gripper">
+    <inertial>
+      <mass value="2e-03"/>
+      <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
+    </inertial>
+  </link>
+  <joint name="RHand" type="revolute">
+    <parent link="r_wrist"/>
+    <child link="r_hand"/>
     <origin rpy="0 0 0" xyz="0.025 0 0"/>
     <axis xyz="1.0 0 0"/>
     <limit effort="0.144" lower="0.02" upper="0.98" velocity="12.56"/>
   </joint>
-  <link name="r_gripper">
+  <link name="r_hand">
     <inertial>
       <mass value="2e-03"/>
       <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>


### PR DESCRIPTION
New URDF structure, to match the one in the [Protolab fork of the naoqi_driver](https://github.com/ProtolabSBRE/naoqi_driver). The grippers are fixed in the wrist frames, and the hands (link for the hand control) are revolute in the wrist frames.