### PR TITLE
Prevent stopSimulation from raising exceptions

### DIFF
--- a/qibullet/simulation_manager.py
+++ b/qibullet/simulation_manager.py
@@ -76,7 +76,12 @@ class SimulationManager:
             physics_client - The id of the simulated instance to be stopped
         """
         self._clearInstance(physics_client)
-        pybullet.disconnect(physicsClientId=physics_client)
+
+        try:
+            pybullet.disconnect(physicsClientId=physics_client)
+
+        except pybullet.error:
+            print("Instance " + str(physics_client) + " already stopped")
 
     def setLightPosition(self, physics_client, light_position):
         """


### PR DESCRIPTION
This PR solves #11, and prevents the [stopSimulation](https://github.com/ProtolabSBRE/qibullet/blob/9c5e1b319a18dd289263eb82f9d7303429bcbe21/qibullet/simulation_manager.py#L71) method from raising a pybullet.error. This is for instance useful if the user decides to close the simulation using the GUI, while the code contains a call to stopSimulation.

**WARNING**: resetSimulation will still raise a pybullet.error if the simulation instance has been stopped